### PR TITLE
[DNM] NetworkSwitcher: Handle VoLTE toggle

### DIFF
--- a/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/NetworkSwitcher.java
+++ b/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/NetworkSwitcher.java
@@ -268,7 +268,7 @@ public class NetworkSwitcher extends Service {
      * @param subID         the subscription ID from {@link #subscriptionsChangedListener}
      * @param isBoot        whether is boot task
      */
-    private void handle4GVoLteToggle(TelephonyManager tm, @Nullable ImsManager imsManager, PersistableBundle carrierConfig, int subID, boolean isBoot) {
+    private void handle4GVoLteToggle(TelephonyManager tm, final ImsManager imsManager, PersistableBundle carrierConfig, int subID, boolean isBoot) {
         if (imsManager == null) {
             d("4gLteToggle: ims manager is null :/");
             return;
@@ -285,11 +285,25 @@ public class NetworkSwitcher extends Service {
         if (isBoot) {
             d("4gLteToggle: Boot task");
 
-            if (Preference.getEnhanced4GEnabled(getApplicationContext(), getPreferredEnhanced4GPref(imsManager))) {
-                d("4gLteToggle: Enhanced 4G was enabled. Enabling ...");
-                imsManager.setEnhanced4gLteModeSetting(true);
+            if (getPreferredEnhanced4GPref(imsManager)) {
+                d("4gLteToggle: Enhanced 4G was ALREADY enabled, toggling Off and On ...");
+                // OFF ...
+                imsManager.setEnhanced4gLteModeSetting(false);
+                new Handler(getMainLooper()).postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Turn ON after 2 sec ...
+                        imsManager.setEnhanced4gLteModeSetting(true);
+                    }
+                }, 2000);
             } else {
-                d("4gLteToggle: Enhanced 4G was disabled. Not enabling.");
+                d("4gLteToggle: Enhanced 4G was expectedly OFF.");
+                if (Preference.getEnhanced4GEnabled(getApplicationContext(), getPreferredEnhanced4GPref(imsManager))) {
+                    d("4gLteToggle: Enhanced 4G was enabled. Enabling ...");
+                    imsManager.setEnhanced4gLteModeSetting(true);
+                } else {
+                    d("4gLteToggle: Enhanced 4G was disabled. Not enabling.");
+                }
             }
         } else {
             d("4gLteToggle: Shutdown/reboot task");

--- a/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/Preference.java
+++ b/hardware/NetworkSwitcher/src/com/yoshino/networkswitcher/Preference.java
@@ -24,7 +24,8 @@ import android.content.SharedPreferences;
  */
 public class Preference {
 
-    public static final String WAS_NETWORK_3G = "network_pref_3g";
+    private static final String WAS_NETWORK_3G = "network_pref_3g";
+    private static final String ENHANCED_4G_VOLTE_ENABLED = "enhanced_4g_volte_enable";
 
     private static SharedPreferences getPreferences(Context context) {
         return context.getApplicationContext().getSharedPreferences("NetworkCycler", Context.MODE_PRIVATE);
@@ -40,5 +41,17 @@ public class Preference {
     }
     public static boolean getWasNetwork3G(Context context, boolean def) {
         return getPreferences(context).getBoolean(WAS_NETWORK_3G, def);
+    }
+
+    /**
+     * This preference stores if VoLTE or 4G Calling preference was enabled
+     */
+    public static void putEnhanced4GEnabled(boolean was, Context context) {
+        SharedPreferences.Editor editor = getPreferences(context).edit();
+        editor.putBoolean(ENHANCED_4G_VOLTE_ENABLED, was);
+        editor.apply();
+    }
+    public static boolean getEnhanced4GEnabled(Context context, boolean def) {
+        return getPreferences(context).getBoolean(ENHANCED_4G_VOLTE_ENABLED, def);
     }
 }


### PR DESCRIPTION
Users have reported of their VoLTE and VoWifi not working until they manually toggle the setting again every time on boot.

This app will now handle this toggling too.

It will toggle VoLTE then network on shutdown/reboot, and toggle network then toggle VoLTE on boot

Please verify it's working by cherry picking the commit as my carrier doesn't provide IMS facilities

Thanks :)